### PR TITLE
feat: server side events tracking

### DIFF
--- a/src/components/Menus/WalletSelectMenu/useWalletSelectContent.tsx
+++ b/src/components/Menus/WalletSelectMenu/useWalletSelectContent.tsx
@@ -8,9 +8,11 @@ import { Avatar, useMediaQuery, useTheme } from '@mui/material';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { TrackingAction, TrackingCategory } from 'src/const';
 import { useAccountConnect } from 'src/hooks/useAccounts';
 import type { CombinedWallet } from 'src/hooks/useCombinedWallets';
 import { useCombinedWallets } from 'src/hooks/useCombinedWallets';
+import { trackServerSideEvent } from 'src/services/serverSideEventsTracking';
 import { useMenuStore, useSettingsStore } from 'src/stores';
 import type { MenuListItem } from 'src/types';
 import { getContrastAlphaColor } from 'src/utils';
@@ -116,6 +118,16 @@ export const useWalletSelectContent = () => {
         ),
         showMoreIcon: false,
         onClick: () => {
+          const name =
+            combinedWallet.evm?.name || combinedWallet.svm?.adapter.name;
+
+          trackServerSideEvent({
+            name: `${TrackingCategory.WalletSelectMenu}.${TrackingAction.WalletSelect}.wallet_opened`,
+            data: {
+              wallet: name,
+            },
+          });
+
           handleWalletClick(combinedWallet);
         },
         styles: {

--- a/src/components/Menus/WalletSelectMenu/useWalletSelectContent.tsx
+++ b/src/components/Menus/WalletSelectMenu/useWalletSelectContent.tsx
@@ -122,8 +122,10 @@ export const useWalletSelectContent = () => {
             combinedWallet.evm?.name || combinedWallet.svm?.adapter.name;
 
           trackServerSideEvent({
-            name: `${TrackingCategory.WalletSelectMenu}.${TrackingAction.WalletSelect}.wallet_opened`,
+            name: `wallet_selected`,
             data: {
+              category: TrackingCategory.WalletSelectMenu,
+              action: TrackingAction.WalletSelect,
               wallet: name,
             },
           });

--- a/src/components/Navbar/NavbarTabs/useNavbarTabs.tsx
+++ b/src/components/Navbar/NavbarTabs/useNavbarTabs.tsx
@@ -9,6 +9,7 @@ import {
   TrackingEventParameter,
 } from 'src/const';
 import { useUserTracking } from 'src/hooks';
+import { trackServerSideEvent } from 'src/services/serverSideEventsTracking';
 import { EventTrackingTool } from 'src/types';
 
 export const useNavbarTabs = () => {
@@ -19,6 +20,12 @@ export const useNavbarTabs = () => {
   const handleClickTab =
     (tab: string) => (event: React.MouseEvent<HTMLDivElement>) => {
       window.history.replaceState(null, document.title, `/${tab}`);
+
+      trackServerSideEvent({
+        name: `${TrackingCategory.Navigation}.${TrackingAction.SwitchTab}.switch_tab_to_${tab}`,
+        data: { [TrackingEventParameter.Tab]: tab },
+      });
+
       trackEvent({
         category: TrackingCategory.Navigation,
         action: TrackingAction.SwitchTab,

--- a/src/components/Navbar/NavbarTabs/useNavbarTabs.tsx
+++ b/src/components/Navbar/NavbarTabs/useNavbarTabs.tsx
@@ -21,11 +21,6 @@ export const useNavbarTabs = () => {
     (tab: string) => (event: React.MouseEvent<HTMLDivElement>) => {
       window.history.replaceState(null, document.title, `/${tab}`);
 
-      trackServerSideEvent({
-        name: `${TrackingCategory.Navigation}.${TrackingAction.SwitchTab}.switch_tab_to_${tab}`,
-        data: { [TrackingEventParameter.Tab]: tab },
-      });
-
       trackEvent({
         category: TrackingCategory.Navigation,
         action: TrackingAction.SwitchTab,
@@ -35,6 +30,15 @@ export const useNavbarTabs = () => {
           EventTrackingTool.ARCx,
           EventTrackingTool.Cookie3,
         ],
+      });
+
+      trackServerSideEvent({
+        name: `switch_tab_to_tab`,
+        data: {
+          category: TrackingCategory.Navigation,
+          action: TrackingAction.SwitchTab,
+          tab: tab,
+        },
       });
     };
 

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -72,8 +72,10 @@ export function WidgetEvents() {
         });
 
         trackServerSideEvent({
-          name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionStarted}.execution_start`,
+          name: `execution_start`,
           data: {
+            category: TrackingCategory.WidgetEvent,
+            action: TrackingAction.OnRouteExecutionStarted,
             value: parseFloat(route.fromAmountUSD),
             ...commonData,
           },
@@ -133,8 +135,10 @@ export function WidgetEvents() {
           });
 
           trackServerSideEvent({
-            name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionUpdated}.execution_update`,
+            name: `execution_update`,
             data: {
+              category: TrackingCategory.WidgetEvent,
+              action: TrackingAction.OnRouteExecutionUpdated,
               value: parseFloat(update.route.fromAmountUSD),
               ...commonData,
             },
@@ -167,8 +171,10 @@ export function WidgetEvents() {
         });
 
         trackServerSideEvent({
-          name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionCompleted}.execution_success`,
+          name: `execution_success`,
           data: {
+            category: TrackingCategory.WidgetEvent,
+            action: TrackingAction.OnRouteExecutionCompleted,
             value: parseFloat(route.fromAmountUSD),
             ...commonData,
           },
@@ -177,7 +183,7 @@ export function WidgetEvents() {
     };
 
     const onRouteExecutionFailed = async (update: RouteExecutionUpdate) => {
-      const data = {
+      const commonData = {
         [TrackingEventParameter.RouteId]: update.route.id,
         [TrackingEventParameter.TxHash]: update.process.txHash,
         [TrackingEventParameter.Status]: update.process.status,
@@ -191,17 +197,21 @@ export function WidgetEvents() {
         category: TrackingCategory.WidgetEvent,
         action: TrackingAction.OnRouteExecutionFailed,
         label: 'execution_error',
-        data,
+        data: commonData,
       });
 
       trackServerSideEvent({
         name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionFailed}.execution_error`,
-        data,
+        data: {
+          category: TrackingCategory.WidgetEvent,
+          action: TrackingAction.OnRouteExecutionFailed,
+          ...commonData,
+        },
       });
     };
 
     const onRouteHighValueLoss = (update: RouteHighValueLossUpdate) => {
-      const data = {
+      const commonData = {
         [TrackingEventParameter.FromAmountUSD]: update.fromAmountUsd,
         [TrackingEventParameter.ToAmountUSD]: update.toAmountUSD,
         [TrackingEventParameter.GasCostUSD]: update.gasCostUSD,
@@ -213,12 +223,16 @@ export function WidgetEvents() {
         action: TrackingAction.OnRouteHighValueLoss,
         category: TrackingCategory.WidgetEvent,
         label: 'click_high_value_loss_accepted',
-        data,
+        data: commonData,
       });
 
       trackServerSideEvent({
         name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteHighValueLoss}.click_high_value_loss_accepted`,
-        data,
+        data: {
+          category: TrackingCategory.WidgetEvent,
+          action: TrackingAction.OnRouteHighValueLoss,
+          ...commonData,
+        },
       });
     };
 

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -17,6 +17,7 @@ import {
 } from 'src/const';
 import { useMultisig } from 'src/hooks';
 import { useAccounts } from 'src/hooks/useAccounts';
+import { trackServerSideEvent } from 'src/services/serverSideEventsTracking';
 import { useActiveTabStore, useMenuStore, useMultisigStore } from 'src/stores';
 import { MultisigConfirmationModal } from '../MultisigConfirmationModal';
 import { MultisigConnectedAlert } from '../MultisigConnectedAlert';
@@ -45,28 +46,41 @@ export function WidgetEvents() {
   useEffect(() => {
     const onRouteExecutionStarted = async (route: Route) => {
       if (!!route.id) {
+        // here
+
+        const commonData = {
+          [TrackingEventParameter.RouteId]: route.id,
+          [TrackingEventParameter.FromToken]: route.fromToken.address,
+          [TrackingEventParameter.ToToken]: route.toToken.address,
+          [TrackingEventParameter.FromChainId]: route.fromChainId,
+          [TrackingEventParameter.ToChainId]: route.toChainId,
+          [TrackingEventParameter.FromAmount]: route.fromAmount,
+          [TrackingEventParameter.ToAmount]: route.toAmount,
+          [TrackingEventParameter.FromAmountUSD]: route.fromAmountUSD,
+          [TrackingEventParameter.ToAmountUSD]: route.toAmountUSD,
+          [TrackingEventParameter.Variant]: Object.values(TabsMap).filter(
+            (el) => el.index === activeTab,
+          )[0].variant,
+        };
+
         trackEvent({
           category: TrackingCategory.WidgetEvent,
           action: TrackingAction.OnRouteExecutionStarted,
           label: 'execution_start',
           value: parseFloat(route.fromAmountUSD),
+          data: commonData,
+        });
+
+        trackServerSideEvent({
+          name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionStarted}.execution_start`,
           data: {
-            [TrackingEventParameter.RouteId]: route.id,
-            [TrackingEventParameter.FromToken]: route.fromToken.address,
-            [TrackingEventParameter.ToToken]: route.toToken.address,
-            [TrackingEventParameter.FromChainId]: route.fromChainId,
-            [TrackingEventParameter.ToChainId]: route.toChainId,
-            [TrackingEventParameter.FromAmount]: route.fromAmount,
-            [TrackingEventParameter.ToAmount]: route.toAmount,
-            [TrackingEventParameter.FromAmountUSD]: route.fromAmountUSD,
-            [TrackingEventParameter.ToAmountUSD]: route.toAmountUSD,
-            [TrackingEventParameter.Variant]: Object.values(TabsMap).filter(
-              (el) => el.index === activeTab,
-            )[0].variant,
+            value: parseFloat(route.fromAmountUSD),
+            ...commonData,
           },
         });
       }
     };
+
     const onRouteExecutionUpdated = async (update: RouteExecutionUpdate) => {
       // check if multisig and open the modal
 
@@ -81,95 +95,130 @@ export function WidgetEvents() {
       if (!!update.process && !!update.route) {
         if (update.process.txHash !== lastTxHashRef.current) {
           lastTxHashRef.current = update.process.txHash;
+
+          const commonData = {
+            label: 'execution_update',
+            [TrackingEventParameter.FromAmountUSD]: update.route.fromAmountUSD,
+            [TrackingEventParameter.ToAmountUSD]: update.route.toAmountUSD,
+            [TrackingEventParameter.FromAmount]: update.route.fromAmount,
+            [TrackingEventParameter.ToAmount]: update.route.toAmount,
+            [TrackingEventParameter.FromToken]: update.route.fromToken.address,
+            [TrackingEventParameter.ToToken]: update.route.toToken.address,
+            [TrackingEventParameter.FromChainId]: update.route.fromChainId,
+            [TrackingEventParameter.ToChainId]: update.route.toChainId,
+            [TrackingEventParameter.RouteId]: `${update.route.id}`,
+            [TrackingEventParameter.Status]: update.process.status,
+            [TrackingEventParameter.TxHash]: update.process.txHash || '',
+            [TrackingEventParameter.TxLink]: update.process.txLink || '',
+            [TrackingEventParameter.Type]: update.process.type,
+            [TrackingEventParameter.GasCostUSD]: update.route.gasCostUSD,
+            [TrackingEventParameter.ErrorCode]:
+              update.process.error?.code || '',
+            [TrackingEventParameter.ErrorMessage]:
+              update.process.error?.message || '',
+            [TrackingEventParameter.InsuranceFeeAmountUSD]:
+              update.route.insurance.feeAmountUsd,
+            [TrackingEventParameter.InsuranceState]:
+              update.route.insurance?.state,
+            nonInteraction: true,
+          };
+
           trackTransaction({
             chain: update.route.fromChainId,
             txhash: update.process.txHash || '',
             category: TrackingCategory.WidgetEvent,
             action: TrackingAction.OnRouteExecutionUpdated,
             value: parseFloat(update.route.fromAmountUSD),
+            data: commonData,
+          });
+
+          trackServerSideEvent({
+            name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionUpdated}.execution_update`,
             data: {
-              label: 'execution_update',
-              [TrackingEventParameter.FromAmountUSD]:
-                update.route.fromAmountUSD,
-              [TrackingEventParameter.ToAmountUSD]: update.route.toAmountUSD,
-              [TrackingEventParameter.FromAmount]: update.route.fromAmount,
-              [TrackingEventParameter.ToAmount]: update.route.toAmount,
-              [TrackingEventParameter.FromToken]:
-                update.route.fromToken.address,
-              [TrackingEventParameter.ToToken]: update.route.toToken.address,
-              [TrackingEventParameter.FromChainId]: update.route.fromChainId,
-              [TrackingEventParameter.ToChainId]: update.route.toChainId,
-              [TrackingEventParameter.RouteId]: `${update.route.id}`,
-              [TrackingEventParameter.Status]: update.process.status,
-              [TrackingEventParameter.TxHash]: update.process.txHash || '',
-              [TrackingEventParameter.TxLink]: update.process.txLink || '',
-              [TrackingEventParameter.Type]: update.process.type,
-              [TrackingEventParameter.GasCostUSD]: update.route.gasCostUSD,
-              [TrackingEventParameter.ErrorCode]:
-                update.process.error?.code || '',
-              [TrackingEventParameter.ErrorMessage]:
-                update.process.error?.message || '',
-              [TrackingEventParameter.InsuranceFeeAmountUSD]:
-                update.route.insurance.feeAmountUsd,
-              [TrackingEventParameter.InsuranceState]:
-                update.route.insurance?.state,
-              nonInteraction: true,
+              value: parseFloat(update.route.fromAmountUSD),
+              ...commonData,
             },
           });
         }
       }
     };
+
     const onRouteExecutionCompleted = async (route: Route) => {
       if (!!route.id) {
+        const commonData = {
+          [TrackingEventParameter.RouteId]: route.id,
+          [TrackingEventParameter.FromChainId]: route.fromChainId,
+          [TrackingEventParameter.FromAmountUSD]: route.fromAmountUSD,
+          [TrackingEventParameter.FromAmount]: route.fromAmount,
+          [TrackingEventParameter.FromToken]: route.fromToken.address,
+          [TrackingEventParameter.ToChainId]: route.toChainId,
+          [TrackingEventParameter.ToAmountUSD]: route.toAmountUSD,
+          [TrackingEventParameter.ToAmount]: route.toAmount,
+          [TrackingEventParameter.ToAmountMin]: route.toAmountMin,
+          [TrackingEventParameter.ToToken]: route.toToken.address,
+        };
+
         trackEvent({
           category: TrackingCategory.WidgetEvent,
           action: TrackingAction.OnRouteExecutionCompleted,
           label: 'execution_success',
           value: parseFloat(route.fromAmountUSD),
+          data: commonData,
+        });
+
+        trackServerSideEvent({
+          name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionCompleted}.execution_success`,
           data: {
-            [TrackingEventParameter.RouteId]: route.id,
-            [TrackingEventParameter.FromChainId]: route.fromChainId,
-            [TrackingEventParameter.FromAmountUSD]: route.fromAmountUSD,
-            [TrackingEventParameter.FromAmount]: route.fromAmount,
-            [TrackingEventParameter.FromToken]: route.fromToken.address,
-            [TrackingEventParameter.ToChainId]: route.toChainId,
-            [TrackingEventParameter.ToAmountUSD]: route.toAmountUSD,
-            [TrackingEventParameter.ToAmount]: route.toAmount,
-            [TrackingEventParameter.ToAmountMin]: route.toAmountMin,
-            [TrackingEventParameter.ToToken]: route.toToken.address,
+            value: parseFloat(route.fromAmountUSD),
+            ...commonData,
           },
         });
       }
     };
+
     const onRouteExecutionFailed = async (update: RouteExecutionUpdate) => {
+      const data = {
+        [TrackingEventParameter.RouteId]: update.route.id,
+        [TrackingEventParameter.TxHash]: update.process.txHash,
+        [TrackingEventParameter.Status]: update.process.status,
+        [TrackingEventParameter.Message]: update.process.message || '',
+        [TrackingEventParameter.ErrorMessage]:
+          update.process.error?.message || '',
+        [TrackingEventParameter.ErrorCode]: update.process.error?.code || '',
+      };
+
       trackEvent({
         category: TrackingCategory.WidgetEvent,
         action: TrackingAction.OnRouteExecutionFailed,
         label: 'execution_error',
-        data: {
-          [TrackingEventParameter.RouteId]: update.route.id,
-          [TrackingEventParameter.TxHash]: update.process.txHash,
-          [TrackingEventParameter.Status]: update.process.status,
-          [TrackingEventParameter.Message]: update.process.message || '',
-          [TrackingEventParameter.ErrorMessage]:
-            update.process.error?.message || '',
-          [TrackingEventParameter.ErrorCode]: update.process.error?.code || '',
-        },
+        data,
+      });
+
+      trackServerSideEvent({
+        name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteExecutionFailed}.execution_error`,
+        data,
       });
     };
 
     const onRouteHighValueLoss = (update: RouteHighValueLossUpdate) => {
+      const data = {
+        [TrackingEventParameter.FromAmountUSD]: update.fromAmountUsd,
+        [TrackingEventParameter.ToAmountUSD]: update.toAmountUSD,
+        [TrackingEventParameter.GasCostUSD]: update.gasCostUSD,
+        [TrackingEventParameter.ValueLoss]: update.valueLoss,
+        [TrackingEventParameter.Timestamp]: Date.now(),
+      };
+
       trackEvent({
         action: TrackingAction.OnRouteHighValueLoss,
         category: TrackingCategory.WidgetEvent,
         label: 'click_high_value_loss_accepted',
-        data: {
-          [TrackingEventParameter.FromAmountUSD]: update.fromAmountUsd,
-          [TrackingEventParameter.ToAmountUSD]: update.toAmountUSD,
-          [TrackingEventParameter.GasCostUSD]: update.gasCostUSD,
-          [TrackingEventParameter.ValueLoss]: update.valueLoss,
-          [TrackingEventParameter.Timestamp]: Date.now(),
-        },
+        data,
+      });
+
+      trackServerSideEvent({
+        name: `${TrackingCategory.WidgetEvent}.${TrackingAction.OnRouteHighValueLoss}.click_high_value_loss_accepted`,
+        data,
       });
     };
 

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -43,9 +43,6 @@ export enum TrackingAction {
   DownloadBrandAssets = 'action_dl_brand_assets',
 
   PoweredBy = 'action_click_powered_by',
-
-  // Server side
-  WalletSelect = 'action_wallet_select',
 }
 
 export enum TrackingCategory {

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -43,6 +43,9 @@ export enum TrackingAction {
   DownloadBrandAssets = 'action_dl_brand_assets',
 
   PoweredBy = 'action_click_powered_by',
+
+  // Server side
+  WalletSelect = 'action_wallet_select',
 }
 
 export enum TrackingCategory {

--- a/src/services/serverSideEventsTracking.ts
+++ b/src/services/serverSideEventsTracking.ts
@@ -1,0 +1,75 @@
+export type AdditionalData = {
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | undefined
+    | AdditionalData
+    | AdditionalData[];
+};
+
+type Event = {
+  name: string;
+  data: AdditionalData;
+};
+type EndpointTypes = 'isLoggedIn' | 'logIn' | 'metrics';
+
+const Endpoints: Record<EndpointTypes, string> = {
+  isLoggedIn: 'auth/is-logged-in',
+  logIn: 'auth/log-in',
+  metrics: 'metrics',
+};
+
+async function request(
+  method: 'POST' | 'GET',
+  endpoint: EndpointTypes,
+  body?: BodyInit,
+) {
+  return fetch(
+    `${import.meta.env.VITE_SERVER_SIDE_TRACKING_URI}${Endpoints[endpoint]}`,
+    {
+      method,
+      body,
+      headers: method === 'POST' ? { 'Content-Type': 'application/json' } : {},
+      credentials: 'include',
+    },
+  );
+}
+
+export const trackServerSideEvent = async ({ name, data }: Event) => {
+  let isLoggedIn = true;
+
+  try {
+    const res = await request('GET', 'isLoggedIn');
+    isLoggedIn = res.ok;
+  } catch (error: unknown) {
+    console.debug('User not logged in');
+    isLoggedIn = false;
+  }
+
+  if (!isLoggedIn) {
+    try {
+      const res = await request('POST', 'logIn');
+      isLoggedIn = res.ok;
+    } catch (error: unknown) {
+      console.error('Error during logging', error);
+    }
+  }
+
+  if (isLoggedIn) {
+    try {
+      await request(
+        'POST',
+        'metrics',
+        JSON.stringify({
+          name,
+          data,
+        }),
+      );
+    } catch (error: unknown) {
+      console.error('Error during tracking', error);
+    }
+  } else {
+    console.error('User not logged in, cannot send tracking event');
+  }
+};


### PR DESCRIPTION
## LI.FI Homework Assignment

The task involved adding server-side event tracking in 3 specific areas:

a) Clicks on the “Exchange” / “Gas” / “Buy” buttons in the top bar, specifying which transaction the user would like to take.

b) Clicks on the “Wallet” logo, specifying which wallet the user selected.

c) Clicks exposed by this view of the LI.FI Widget.

The task has been comprehensively realized, incorporating both backend service adjustments and frontend changes. The current merge request represents a (preliminary!) implementation on the frontend side.

### Implementation Description

- No interference with the current metrics solution.
- Creation of a serverSideEvents tracking service from the task's realization.

### Things to Improve/Consider

- Utilizing react-query/axios interceptors for session management when connecting with the backend. The current solution is based on several REST API calls and could be further optimized by ensuring a "background" connection with the backend and automatically extending the session when sending metrics.

- Creating a custom hook for sending events.

- Additional client identification by linking with a wallet. Easy to implement by sending a metric in the trackConnectWallet function inside useUserTracking.

### Setup

A new environmental variable named `VITE_SERVER_SIDE_TRACKING_URI` is required for the setup.